### PR TITLE
Integrate project with CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,15 @@
+engines:
+  bundler-audit:
+    enabled: true
+  rubocop:
+    enabled: true
+  fixme:
+    enabled: true
+
+ratings:
+  paths:
+    - features/page_objects/**.rb
+    - Gemfile.lock
+
+exclude_paths:
+  - features/


### PR DESCRIPTION
This change integrates the project with [CodeClimate](https://codeclimate.com), an online service that consolidates the results from a suite of static analysis tools into a single, real-time report.

Specifically we are adding a `.codeclimate.yml` file which is used to configure which tools CodeClimate actually analyses this project with.