### PR TITLE
Fix ratings and exclude_paths in .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,10 @@ engines:
 ratings:
   paths:
     - features/page_objects/**.rb
-    - Gemfile.lock
 
 exclude_paths:
-  - features/
+  - features/step_definitions/
+  - "**.feature"
+  - Gemfile.lock
+  - LICENSE
+  - "**.md"


### PR DESCRIPTION
The previous setup of the `ratings` and `exclude_paths` sections in `.codeclimate.yml` essentially meant nothing of value was being analysed. Essentially we just want the page objects analysed by CodeClimate at this time.

N.B. The problem with CodeClimate is it will only analyse the master branch, so to see if something works we have to merge the change and then check [CodeClimate](https://codeclimate.com/github/EnvironmentAgency/flood-risk-acceptance-tests).