### PR TITLE
Add first validation scenario and feature

### DIFF
--- a/features/page_objects/add_exemption_page.rb
+++ b/features/page_objects/add_exemption_page.rb
@@ -13,4 +13,10 @@ class AddExemptionPage < SitePrism::Page
     submit_button.click
   end
 
+  def exemption_checked?(code)
+    return false if code.nil?
+
+    exemptions.find { |chk| chk['data-code'] == code }.checked?
+  end
+
 end

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -15,6 +15,24 @@ Given(/^I register exemption FRA(\d+)$/) do |id|
   )
 end
 
+Given(/^I select exemption FRA(\d+)$/) do |code|
+  @app.add_exemption_page.submit(exemption: "FRA#{code}")
+
+  expect(page).to have_content("FRA#{code}")
+end
+
+Given(/^I then opt to change FRA(\d+)$/) do |code|
+  # We can get away with just selecting the first link because currently you can
+  # only select one exemption so there will only ever be one link
+  @app.check_exemptions_page.remove_links.first.click
+
+  expect(@app.add_exemption_page.exemption_checked?("FRA#{code}")).to be false
+end
+
+Then(/^I will be taken back to the add exemptions page$/) do
+  expect(page).to have_content 'Select the exemption you want to register'
+end
+
 When(/^I confirm my registration$/) do
   @app.declaration_page.declaration_button.click
 end

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -1,0 +1,12 @@
+Feature: Validations within the digital service
+  As a user
+  I want to know that if I make a mistake
+  The service will tell me how to correct it
+  So that I don't have to resort to calling someone
+
+@frontoffice
+Scenario: External user adds an exemption then changes their mind
+  Given I am an external user
+    And I select exemption FRA2
+    But I then opt to change FRA2
+   Then I will be taken back to the add exemptions page


### PR DESCRIPTION
The initial features and scenarios in this projct were ported from an existing project.

During this process the scenario to check that a user is returned to the add exemption page when they remove their previously selected exemption was found in the local authority feature. However as you never even get to the org type it was thought to be clearer to move the scenario to its own feature named *Validation*.