### PR TITLE
Add initial dredging feature and scenarios

### DIFF
--- a/features/dredging.feature
+++ b/features/dredging.feature
@@ -1,0 +1,17 @@
+Feature: Dredging distance is required for certain exemptions
+  As a business
+  For certain exemptions
+  I need to know the approximate dredging length
+  To help ensure they are not exceeding the maximum length of 1500 metres
+
+@frontoffice
+Scenario: External user adds an exemption which requires dredging length is captured
+  Given I am an external user
+    And I select exemption FRA23
+   Then I will be asked to give the approximate length of dredging planned
+
+@frontoffice
+Scenario: External user adds an exemption which does not require a dredging length
+ Given I am an external user
+   And I select exemption FRA24
+  Then I will NOT be asked to give the approximate length of dredging planned

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -21,6 +21,29 @@ Given(/^I select exemption FRA(\d+)$/) do |code|
   expect(page).to have_content("FRA#{code}")
 end
 
+Then(/^I will be asked to give the approximate length of dredging planned$/) do
+  # The previous step is assumed to be 'I select exemption FRA#' which does not
+  # click the submit button, hence its the first action we have to take here.
+  @app.check_exemptions_page.submit_button.click
+
+  expect(@app.grid_reference_page.dredging_length).not_to be_nil
+end
+
+# rubocop:disable Lint/HandleExceptions
+Then(/^I will NOT be asked to give the approximate length of dredging planned$/) do
+  # The previous step is assumed to be 'I select exemption FRA#' which does not
+  # click the submit button, hence its the first action we have to take here.
+  @app.check_exemptions_page.submit_button.click
+
+  begin
+    expect(@app.grid_reference_page.dredging_length).to raise_error Capybara::ElementNotFound
+  rescue StandardError
+    # We do nothing with the error. We just don't want it to bubble up as
+    # a failure.
+  end
+end
+# rubocop:enable Lint/HandleExceptions
+
 Given(/^I then opt to change FRA(\d+)$/) do |code|
   # We can get away with just selecting the first link because currently you can
   # only select one exemption so there will only ever be one link


### PR DESCRIPTION
The initial features and scenarios in this project were ported from an existing one.

During this process the scenarios to test that a field which asks for approximate dredging length is only shown when a certain exemption is picked was found in the local authority feature. However as you never even get to the org type it was thought to be clearer to move the scenario to its own feature named *dredging*.