### PR TITLE
Add details on tags and their usage to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,14 @@ git:
 # enable Bundler caching
 # https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
 cache: bundler
+
+# Using the ability to customise the Travis build to check for 'temporary' tags
+# i.e. tags often used when working on a feature/scenario but which we don't
+# want appearing in the final commit to master
+before_script:
+  - echo "Checking for use of temporary tags in .feature files"
+  # Reworking of http://stackoverflow.com/a/30495279/6117745
+  # If grep returns 0 (match found), test 0 -eq 1 will return 1.
+  # If grep returns 1 (no match found), test 1 -eq 1 will return 0.
+  # If grep returns 2 (error), test 2 -eq 1 will return 1.
+  - grep -r --include="*.feature" "@wip\|@focus" features/; test $? -eq 1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,43 @@ You can create [multiple config files](https://github.com/EnvironmentAgency/quke
 QUKE_CONFIG='chrome.config.yml' bundle exec quke
 ```
 
+## Use of tags
+
+[Cucumber](https://cucumber.io/) has an inbuilt feature called [tags](https://github.com/cucumber/cucumber/wiki/Tags).
+
+These can be added to a [feature](https://github.com/cucumber/cucumber/wiki/Feature-Introduction) or individual **scenarios**.
+
+```gherkin
+@functional
+Feature: Validations within the digital service
+```
+
+```gherkin
+@frontoffice @happypath
+Scenario: Registration by an individual
+```
+
+When applied you then have the ability to filter which tests will be used during any given run
+
+```bash
+bundle exec quke --tags @frontoffice # Run only things tagged with this
+bundle exec quke --tags @frontoffice,@happypath # Run all things with these tags
+bundle exec quke --tags ~@functional # Don't run anything with this tag (run everything else)
+```
+
+### In this project
+
+To have consistency across the project the following tags are defined and should be used in the following ways
+
+|Tag|Description|
+|---|---|
+|@frontoffice|Any feature or scenario expected to be run against the front office application|
+|@happypath|A scenario which details a complete registration with no errors|
+|@functional|Any feature or scenario which is testing just a specific function of the service e.g. validation errors|
+|@ci|A feature that is intended to be run only on our continuous integration service (you should never need to use this tag).|
+
+It's also common practice to use a custom tag whilst working on a new feature or scenario e.g. `@focus` or `@wip`. That is perfectly acceptable but please ensure they are removed before your change is merged.
+
 ## Contributing to this project
 
 If you have an idea you'd like to contribute please log an issue.

--- a/features/continuous_integration.feature
+++ b/features/continuous_integration.feature
@@ -1,9 +1,9 @@
+@ci
 Feature: Continuous integration check of the project
   As a contributor to this project
   I want to know a change I made hasn't broken it (though it may have failing tests)
   So that we have a reliable base on which to build our acceptance tests
 
-  @ci
   Scenario: Check Quke is working
     Given a cucumber that is 30 cm long
      When I cut it in halves

--- a/features/dredging.feature
+++ b/features/dredging.feature
@@ -1,17 +1,18 @@
+@functional
 Feature: Dredging distance is required for certain exemptions
   As a business
   For certain exemptions
   I need to know the approximate dredging length
   To help ensure they are not exceeding the maximum length of 1500 metres
 
-@frontoffice
-Scenario: External user adds an exemption which requires dredging length is captured
-  Given I am an external user
-    And I select exemption FRA23
-   Then I will be asked to give the approximate length of dredging planned
+  @frontoffice
+  Scenario: External user adds an exemption which requires dredging length is captured
+    Given I am an external user
+      And I select exemption FRA23
+     Then I will be asked to give the approximate length of dredging planned
 
-@frontoffice
-Scenario: External user adds an exemption which does not require a dredging length
- Given I am an external user
-   And I select exemption FRA24
-  Then I will NOT be asked to give the approximate length of dredging planned
+  @frontoffice
+  Scenario: External user adds an exemption which does not require a dredging length
+   Given I am an external user
+     And I select exemption FRA24
+    Then I will NOT be asked to give the approximate length of dredging planned

--- a/features/local_authority_registration.feature
+++ b/features/local_authority_registration.feature
@@ -3,10 +3,10 @@ Feature: Local authority registers a flood risk activity exemption
   I want to register a location for a flood risk activity exemption
   So that I can check that my activity does not harm the environment in that area
 
-@frontoffice @happy_path
-Scenario: Registration by a local authority
-  Given I am an external user
-    And I register exemption FRA5
-    And I am a local authority
-   When I confirm my registration
-   Then I will see confirmation my registration has been submitted
+  @frontoffice @happy_path
+  Scenario: Registration by a local authority
+    Given I am an external user
+      And I register exemption FRA5
+      And I am a local authority
+     When I confirm my registration
+     Then I will see confirmation my registration has been submitted

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -1,3 +1,4 @@
+@functional
 Feature: Validations within the digital service
   As a user
   I want to know that if I make a mistake


### PR DESCRIPTION
To ensure consistent use of tags across the project, and also to provide a definition of when to use them for new users, this change adds details about them to `README.md`.

It also makes house keeping changes to the feature and scenario files to ensure they are consistent with the definitions we've set out.