### PR TITLE
Add feature for external 'other' testing

### DIFF
--- a/features/other_registration.feature
+++ b/features/other_registration.feature
@@ -1,0 +1,12 @@
+Feature: 'Other' registers a flood risk activity exemption
+  As an charity
+  I want to register a location for a flood risk activity exemptions
+  So that I can check that my activity does not harm the environment in that area
+
+  @frontoffice @happy_path
+  Scenario: Registration by an 'Other' organisation (eg trust, charity or club)
+    Given I am an external user
+      And I register exemption FRA16
+      And I am a charity
+     When I confirm my registration
+     Then I will see confirmation my registration has been submitted

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -1,0 +1,41 @@
+Given(/^I am a charity$/) do
+  # User type page
+  @app.user_type_page.submit(org_type: 'other')
+
+  # Organisation name page
+  @app.organisation_name_page.submit(other_name: 'Boy scouts')
+
+  # Postcode page
+  @app.postcode_page.submit(other_postcode: 'BS1 5AH')
+
+  # Address page - select address from post code lookup list
+  @app.address_page.submit(
+    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+  )
+
+  # Correspondence contact name page
+  @app.correspondence_contact_name_page.submit(
+    full_name: 'Joe Bloggs',
+    position: 'Project Manager'
+  )
+
+  # Correspondence contact telephone page
+  @app.correspondence_contact_telephone_page.submit(
+    telephone_number: '01234567899'
+  )
+
+  # Correspondence contact email address page
+  @app.correspondence_contact_email_page.submit(
+    email: 'tim.stone.ea@gmail.com',
+    confirm_email: 'tim.stone.ea@gmail.com'
+  )
+
+  # Email someone else page
+  @app.email_someone_else_page.submit(
+    email: 'tim.stone.ea+1@gmail.com',
+    confirm_email: 'tim.stone.ea+1@gmail.com'
+  )
+
+  # Check your answers page
+  @app.check_your_answers_page.submit_button.click
+end


### PR DESCRIPTION
This change adds the initial register as an 'other' (eg trust, charity or club) scenario.