### PR TITLE
Create distinct check your answers feature

### DIFF
--- a/features/check_your_anwsers.feature
+++ b/features/check_your_anwsers.feature
@@ -1,0 +1,12 @@
+@functional
+Feature: The 'Check your answers' page
+  As a user
+  I want to see the details I've entered
+  Before I complete it
+  So that I can be confident I am submitting the correct information
+
+  @frontoffice
+  Scenario: Simple individual registration
+    Given I am an external user
+     When I select exemption FRA2 as an individual
+     Then I will see all the details I entered as an individual

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -1,0 +1,68 @@
+# rubocop:disable Metrics/BlockLength
+When(/^I select exemption FRA2 as an individual$/) do
+
+  # Add exemption page
+  @app.add_exemption_page.submit(exemption: 'FRA2')
+
+  # Check exemptions page
+  expect(page).to have_content('FRA2')
+  @app.check_exemptions_page.submit_button.click
+
+  # Grid reference page
+  @app.grid_reference_page.submit(
+    grid_reference: 'ST 58132 72695',
+    description: 'Location of activity'
+  )
+
+  # User type page
+  @app.user_type_page.submit(org_type: 'individual')
+
+  # Organisation name page
+  @app.organisation_name_page.submit(individual_name: 'Napoleon Solo')
+
+  # Postcode page
+  @app.postcode_page.submit(individual_postcode: 'BS1 5AH')
+
+  # Address page - select address from post code lookup list
+  @app.address_page.submit(
+    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+  )
+
+  # Correspondence contact name page
+  @app.correspondence_contact_name_page.submit(
+    full_name: 'Napoleon Solo',
+    position: 'Owner'
+  )
+
+  # Correspondence contact telephone page
+  @app.correspondence_contact_telephone_page.submit(
+    telephone_number: '01234567899'
+  )
+
+  # Correspondence contact email address page
+  @app.correspondence_contact_email_page.submit(
+    email: 'tim.stone.ea@gmail.com',
+    confirm_email: 'tim.stone.ea@gmail.com'
+  )
+
+  # Email someone else page
+  @app.email_someone_else_page.submit(
+    email: 'tim.stone.ea+1@gmail.com',
+    confirm_email: 'tim.stone.ea+1@gmail.com'
+  )
+
+end
+# rubocop:enable Metrics/BlockLength
+
+Then(/^I will see all the details I entered as an individual$/) do
+  # Check your answers page
+  expect(page).to have_content 'Electrical cable service crossing over a main river'
+  expect(page).to have_content 'ST 58132 72695'
+  expect(page).to have_content 'Location of activity'
+  expect(page).to have_content 'Individual'
+  expect(page).to have_content 'Napoleon Solo'
+  expect(page).to have_content 'HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+  expect(page).to have_content 'Napoleon Solo (Owner)'
+  expect(page).to have_content '01234567899'
+  expect(page).to have_content 'tim.stone.ea@gmail.com'
+end

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -3,10 +3,10 @@ Given(/^I am an external user$/) do
   @app.front_office_home_page.load
 end
 
-Given(/^I register exemption FRA(\d+)$/) do |id|
-  @app.add_exemption_page.submit(exemption: "FRA#{id}")
+Given(/^I register exemption FRA(\d+)$/) do |code|
+  @app.add_exemption_page.submit(exemption: "FRA#{code}")
 
-  expect(page).to have_content("FRA#{id}")
+  expect(page).to have_content("FRA#{code}")
   @app.check_exemptions_page.submit_button.click
 
   @app.grid_reference_page.submit(

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 Given(/^I am a local authority$/) do
   # User type page
   @app.user_type_page.submit(org_type: 'local_authority')
@@ -37,15 +36,6 @@ Given(/^I am a local authority$/) do
     confirm_email: 'tim.stone.ea+1@gmail.com'
   )
 
-  # Check your answers page
-  expect(page).to have_content 'Footbridge over a main river not more than 8 metres wide from bank to bank'
-  expect(page).to have_content 'tim.stone.ea@gmail.com'
-  expect(page).to have_content 'Joe Bloggs'
-  expect(page).to have_content 'ST 58132 72695'
-  expect(page).to have_content 'Testminster council'
-  expect(page).to have_content 'HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
-  expect(page).to have_content 'Local authority or public body'
   @app.check_your_answers_page.submit_button.click
 
 end
-# rubocop:enable Metrics/BlockLength

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -5,9 +5,9 @@ Feature: Validations within the digital service
   The service will tell me how to correct it
   So that I don't have to resort to calling someone
 
-@frontoffice
-Scenario: External user adds an exemption then changes their mind
-  Given I am an external user
-    And I select exemption FRA2
-    But I then opt to change FRA2
-   Then I will be taken back to the add exemptions page
+  @frontoffice
+  Scenario: External user adds an exemption then changes their mind
+    Given I am an external user
+      And I select exemption FRA2
+      But I then opt to change FRA2
+     Then I will be taken back to the add exemptions page


### PR DESCRIPTION
Currently the scenario *Registration by a local authority* in [local_authority_registration.feature](features/local_authority_registration.feature) has additional content in its `I am a local authority` step.

This is a series of `expect()` statements that are checking the content of the **Check your answers** page. This change brings the scenario inline with the rest of the registration scenarios by moving this to a new **functional** feature that provides a focus for the **check your answers** page.