### PR TITLE
Fix missing http check in convert_url function

### DIFF
--- a/features/page_objects/back_office_home_page.rb
+++ b/features/page_objects/back_office_home_page.rb
@@ -14,8 +14,8 @@ class BackOfficeHomePage < SitePrism::Page
     # insenstive). In both cases we replace that the prefix above.
     admin_url = if host_url =~ %r{https://}i
                   host_url.gsub(%r{https://}i, prefix)
-                elsif host_url =~ %r{https://}i
-                  host_url.gsub(%r{https://}i, prefix)
+                elsif host_url =~ %r{http://}i
+                  host_url.gsub(%r{http://}i, prefix)
                 end
     admin_url
   end


### PR DESCRIPTION
The `convert_url()` function is part of `BackOfficeHomePage` and is used to take a front office url and convert it to a back office one.

It is assumed the front office url will be set in `.config.yml`, but rather than having to hard code the back office urls, or have seperate config files for back office and front office testing the `convert_url()` function allows both kinds of tests to be run together.

The first implementation of the function though duplicated its pattern matching logic i.e. it first checks if the current url prefix is **https://**, and then peforms the exact same check. The second check should have been for **http://**.

This change fixes the error.