### PR TITLE
Update expect's in login steps to use SitePrism

### DIFF
--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -22,7 +22,7 @@ Then(/^I will be able to login$/) do
 
   # We could just do a `expect(page).to have_content()`` but doing the following
   # also checks the alert element appears
-  expect(@app.search_page.alert_success.text).to end_with("You've successfully signed in")
+  expect(@app.search_page).to have_alert_success
 
 end
 
@@ -30,6 +30,6 @@ Then(/^I will NOT be able to login$/) do
 
   # We could just do a `expect(page).to have_content()`` but doing the following
   # also checks the alert element appears
-  expect(@app.back_office_home_page.alert_invalid.text).to end_with('Invalid email or password')
+  expect(@app.back_office_home_page).to have_alert_invalid
 
 end


### PR DESCRIPTION
Realised that we weren't making use of [SitePrism](https://github.com/natritmeyer/site_prism#testing-for-the-existence-of-the-element) when it came to testing for the existence of an element. Previously we would get the element but then check a property of it.

This change updates the syntax used in our back office login `expect` statements to use features built into **SitePrism** to do this kind of checking.

Doing this makes the steps more maintainable, and the logic simpler to read and understand.