### PR TITLE
Refactor BackOfficeHomePage to separate UI logic

### DIFF
--- a/features/page_objects/app.rb
+++ b/features/page_objects/app.rb
@@ -105,6 +105,11 @@ class App
     @last_page = BackOfficeHomePage.new
   end
 
+  # / (when not signed in)
+  def login_page
+    @last_page = LoginPage.new
+  end
+
   # / (once signed in)
   def search_page
     @last_page = SearchPage.new

--- a/features/page_objects/back_office_home_page.rb
+++ b/features/page_objects/back_office_home_page.rb
@@ -24,18 +24,4 @@ class BackOfficeHomePage < SitePrism::Page
   # else it will be unable to find it.
   set_url("#{BackOfficeHomePage.convert_url}/")
 
-  element(:alert_invalid, "div.alert-danger[role='alert']", text: 'Invalid email or password')
-
-  element(:email, '#user_email')
-  element(:password, '#user_password')
-
-  element(:submit_button, "input[name='commit']")
-
-  def submit(args = {})
-    email.set(args[:email]) if args.key?(:email)
-    password.set(args[:password]) if args.key?(:password)
-
-    submit_button.click
-  end
-
 end

--- a/features/page_objects/login_page.rb
+++ b/features/page_objects/login_page.rb
@@ -1,0 +1,17 @@
+class LoginPage < SitePrism::Page
+
+  element(:alert_invalid, "div.alert-danger[role='alert']", text: 'Invalid email or password')
+
+  element(:email, '#user_email')
+  element(:password, '#user_password')
+
+  element(:submit_button, "input[name='commit']")
+
+  def submit(args = {})
+    email.set(args[:email]) if args.key?(:email)
+    password.set(args[:password]) if args.key?(:password)
+
+    submit_button.click
+  end
+
+end

--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -1,7 +1,7 @@
 Given(/^I have a valid username and password$/) do
 
-  # Back office login page page
-  @app.back_office_home_page.submit(
+  # Back office login page
+  @app.login_page.submit(
     email: 'alan.cruikshanks@environment-agency.gov.uk',
     password: 'Abcde12345'
   )
@@ -10,8 +10,8 @@ end
 
 Given(/^I have an invalid username and password$/) do
 
-  # Back office login page page
-  @app.back_office_home_page.submit(
+  # Back office login page
+  @app.login_page.submit(
     email: 'mister.tumble@example.co.uk',
     password: 'Abcde12345'
   )
@@ -30,6 +30,6 @@ Then(/^I will NOT be able to login$/) do
 
   # We could just do a `expect(page).to have_content()`` but doing the following
   # also checks the alert element appears
-  expect(@app.back_office_home_page).to have_alert_invalid
+  expect(@app.login_page).to have_alert_invalid
 
 end


### PR DESCRIPTION
This change makes a distinction between the functionality needed to set the root url for a test, which is either the front or back office home page, and interactions with it.

In the front office the root or home page is simply a check list with a continue button. In the back office though it can be different pages depending on the context; when not signed in its the login page, but when you are signed in it becomes the search page.

To make a clear distinction between the logic needed to set the root url at the start of a scenario, and that needed to interact with the various pages this change splits out the login UI logic into a new `logic_page.rb` page object (`search_page.rb` already follows this pattern). The `set_url` logic is left in `back_office_home_page.rb`.