### PR TITLE
Add SitePrism section for admin nav bar

### DIFF
--- a/features/page_objects/admin_nav_bar_section.rb
+++ b/features/page_objects/admin_nav_bar_section.rb
@@ -1,0 +1,28 @@
+class AdminNavBarSection < SitePrism::Section
+
+  # IMPORTANT! Because of the way the nav-bar works in order to see the options
+  # you first have to click the relevant menu. For example to 'see' i.e. be able
+  # to click the export_option you first have to click on registrations_menu
+  # @app.search_page.nav_bar.registrations_menu.click
+  # @app.search_page.nav_bar.search_option.click
+  # This is just a factor of how bootstrap works.
+  #
+  # The CSS selectors were identified by using the Chrome addin
+  # http://selectorgadget.com/. You can also test them using the Chrome
+  # developer tools. Open them up, select the elements tab and then ctrl/cmd+f
+  # You should get an input field into which you can enter your selector and
+  # confirm/test its working. See
+  # https://developers.google.com/web/updates/2015/05/search-dom-tree-by-css-selector
+
+  element(:registrations_menu, '.dropdown:nth-child(1) .dropdown-toggle')
+  element(:search_option, '.dropdown-menu li:nth-child(1) a')
+  element(:new_option, '.dropdown-menu li:nth-child(2) a')
+  element(:export_option, '.dropdown-menu li~ li+ li a')
+
+  element(:users_menu, '.dropdown+ .dropdown .dropdown-toggle')
+  element(:view_users_option, '.dropdown-menu li:nth-child(1) a')
+  element(:invite_user_option, '.dropdown-menu li+ li a')
+
+  element(:sign_out_link, "a[href='/users/sign_out']")
+
+end

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -7,4 +7,6 @@ class SearchPage < SitePrism::Page
 
   element(:search_button, "input[type='submit'][value='Search']")
 
+  section(:nav_bar, AdminNavBarSection, '.navbar-collapse')
+
 end


### PR DESCRIPTION
This change adds a [SitePrism section](https://github.com/natritmeyer/site_prism#sections) which contains all the logic needed for selecting the elements of the nav bar in the back office system.

A **SitePrism** section

> allows you to model sections of a page that appear on multiple pages or that appear a number of times on a page separately from Pages.

So in our case once a user is signed into the back office, the nav bar appears on every page. By creating a section object we can interact with the nav bar from each page, but maintain all the logic in one place.