### PR TITLE
Rubocop and CSS selector house keeping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,12 @@ Style/EmptyLinesAroundClassBody:
 Style/EmptyLinesAroundBlockBody:
   Enabled: false
 
+# There are no relative performance improvements using '' over "", therefore we
+# believe there is more value in using "" for all strings irrespective of
+# whether string interpolation is used
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
 # We believe the default 80 characters is too restrictive and that lines can
 # still be readable and maintainable when no more than 120 characters. This also
 # allows us to maximise our screen space.

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'quke'
+gem "quke"
 
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.
-gem 'rake'
+gem "rake"
 
 # We use rubocop in all our Ruby based projects to try and ensure consistency
 # in the code we write across all our projects.
-gem 'rubocop', require: false
+gem "rubocop", require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
 task default: :run
 
 # Remember to create an environment variable in Travis (can be set to anything)!
-if ENV['TRAVIS']
+if ENV["TRAVIS"]
   # Setting the default is additive. So if we didn't add the following line
   # :default would now run both all tests and rubocop
   Rake::Task[:default].clear
   task default: [:ci]
 end
 
-desc 'Run all scenarios (eq to bundle exec quke)'
+desc "Run all scenarios (eq to bundle exec quke)"
 task :run do
   sh %( bundle exec quke )
 end
 
-desc 'Runs the tests used by continuous integration to check the project'
+desc "Runs the tests used by continuous integration to check the project"
 task :ci do
-  Rake::Task['rubocop'].invoke
+  Rake::Task["rubocop"].invoke
   sh %( bundle exec quke --tags @ci )
 end

--- a/features/page_objects/add_exemption_page.rb
+++ b/features/page_objects/add_exemption_page.rb
@@ -7,7 +7,7 @@ class AddExemptionPage < SitePrism::Page
 
   def submit(args = {})
     if args.key?(:exemption)
-      exemptions.find { |chk| chk['data-code'] == args[:exemption] }.click
+      exemptions.find { |chk| chk["data-code"] == args[:exemption] }.click
     end
 
     submit_button.click
@@ -16,7 +16,7 @@ class AddExemptionPage < SitePrism::Page
   def exemption_checked?(code)
     return false if code.nil?
 
-    exemptions.find { |chk| chk['data-code'] == code }.checked?
+    exemptions.find { |chk| chk["data-code"] == code }.checked?
   end
 
 end

--- a/features/page_objects/address_page.rb
+++ b/features/page_objects/address_page.rb
@@ -1,7 +1,7 @@
 class AddressPage < SitePrism::Page
 
   element(:show_list, "input[id='address_match_selection']")
-  element(:results_dropdown, 'select#address_match_selection')
+  element(:results_dropdown, "select#address_match_selection")
 
   element(:address_premises, "input[id='address_premises']")
   element(:street_address, "input[id='address_street_address']")

--- a/features/page_objects/address_page.rb
+++ b/features/page_objects/address_page.rb
@@ -1,12 +1,12 @@
 class AddressPage < SitePrism::Page
 
-  element(:show_list, "input[id='address_match_selection']")
+  element(:show_list, "input#address_match_selection")
   element(:results_dropdown, "select#address_match_selection")
 
-  element(:address_premises, "input[id='address_premises']")
-  element(:street_address, "input[id='address_street_address']")
-  element(:address_locality, "input[id='address_locality']")
-  element(:address_city, "input[id='address_city']")
+  element(:address_premises, "input#address_premises")
+  element(:street_address, "input#address_street_address")
+  element(:address_locality, "input#address_locality")
+  element(:address_city, "input#address_city")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/admin_nav_bar_section.rb
+++ b/features/page_objects/admin_nav_bar_section.rb
@@ -14,14 +14,14 @@ class AdminNavBarSection < SitePrism::Section
   # confirm/test its working. See
   # https://developers.google.com/web/updates/2015/05/search-dom-tree-by-css-selector
 
-  element(:registrations_menu, '.dropdown:nth-child(1) .dropdown-toggle')
-  element(:search_option, '.dropdown-menu li:nth-child(1) a')
-  element(:new_option, '.dropdown-menu li:nth-child(2) a')
-  element(:export_option, '.dropdown-menu li~ li+ li a')
+  element(:registrations_menu, ".dropdown:nth-child(1) .dropdown-toggle")
+  element(:search_option, ".dropdown-menu li:nth-child(1) a")
+  element(:new_option, ".dropdown-menu li:nth-child(2) a")
+  element(:export_option, ".dropdown-menu li~ li+ li a")
 
-  element(:users_menu, '.dropdown+ .dropdown .dropdown-toggle')
-  element(:view_users_option, '.dropdown-menu li:nth-child(1) a')
-  element(:invite_user_option, '.dropdown-menu li+ li a')
+  element(:users_menu, ".dropdown+ .dropdown .dropdown-toggle")
+  element(:view_users_option, ".dropdown-menu li:nth-child(1) a")
+  element(:invite_user_option, ".dropdown-menu li+ li a")
 
   element(:sign_out_link, "a[href='/users/sign_out']")
 

--- a/features/page_objects/back_office_home_page.rb
+++ b/features/page_objects/back_office_home_page.rb
@@ -8,7 +8,7 @@ class BackOfficeHomePage < SitePrism::Page
   # is also a class method.
   def self.convert_url
     host_url = Capybara.app_host
-    prefix = 'https://admin-'
+    prefix = "https://admin-"
 
     # We check whether the url starts with either https or http (case
     # insenstive). In both cases we replace that the prefix above.

--- a/features/page_objects/correspondence_contact_email.rb
+++ b/features/page_objects/correspondence_contact_email.rb
@@ -1,7 +1,7 @@
 class CorrespondenceContactEmailPage < SitePrism::Page
 
-  element(:email, "input[id='correspondence_contact_email_email_address']")
-  element(:confirm_email, "input[id='correspondence_contact_email_email_address_confirmation']")
+  element(:email, "input#correspondence_contact_email_email_address")
+  element(:confirm_email, "input#correspondence_contact_email_email_address_confirmation")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/email_someone_else_page.rb
+++ b/features/page_objects/email_someone_else_page.rb
@@ -1,7 +1,7 @@
 class EmailSomeoneElsePage < SitePrism::Page
 
-  element(:email, "input[id='email_someone_else_email_address']")
-  element(:confirm_email, "input[id='email_someone_else_email_address_confirmation']")
+  element(:email, "input#email_someone_else_email_address")
+  element(:confirm_email, "input#email_someone_else_email_address_confirmation")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/front_office_home_page.rb
+++ b/features/page_objects/front_office_home_page.rb
@@ -1,6 +1,6 @@
 class FrontOfficeHomePage < SitePrism::Page
 
-  set_url('/enrollments/new')
+  set_url("/enrollments/new")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/grid_reference_page.rb
+++ b/features/page_objects/grid_reference_page.rb
@@ -1,8 +1,8 @@
 class GridReferencePage < SitePrism::Page
 
-  element(:grid_reference, "input[id='grid_reference_grid_reference']")
+  element(:grid_reference, "input#grid_reference_grid_reference")
   element(:description, "textarea[name='grid_reference[description]']")
-  element(:dredging_length, "input[id='grid_reference_dredging_length']")
+  element(:dredging_length, "input#grid_reference_dredging_length")
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/login_page.rb
+++ b/features/page_objects/login_page.rb
@@ -1,9 +1,9 @@
 class LoginPage < SitePrism::Page
 
-  element(:alert_invalid, "div.alert-danger[role='alert']", text: 'Invalid email or password')
+  element(:alert_invalid, "div.alert-danger[role='alert']", text: "Invalid email or password")
 
-  element(:email, '#user_email')
-  element(:password, '#user_password')
+  element(:email, "#user_email")
+  element(:password, "#user_password")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/organisation_name_page.rb
+++ b/features/page_objects/organisation_name_page.rb
@@ -1,11 +1,11 @@
 class OrganisationNamePage < SitePrism::Page
 
-  element(:local_authority_name, "input[id='local_authority_name']")
-  element(:ltd_company_name, "input[id='limited_company_name_name']")
-  element(:llp_name, "input[id='limited_liability_partnership_name_name']")
-  element(:other_name, "input[id='other_name']")
-  element(:partnership_full_name, "input[id='partnership_full_name']")
-  element(:individual_name, "input[id='individual_name_name']")
+  element(:local_authority_name, "input#local_authority_name")
+  element(:ltd_company_name, "input#limited_company_name_name")
+  element(:llp_name, "input#limited_liability_partnership_name_name")
+  element(:other_name, "input#other_name")
+  element(:partnership_full_name, "input#partnership_full_name")
+  element(:individual_name, "input#individual_name_name")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/partnership_details_page.rb
+++ b/features/page_objects/partnership_details_page.rb
@@ -11,7 +11,7 @@ class PartnershipPage < SitePrism::Page
   # Ref: actual content of data-confirm atttribute would be
   # 'Are you sure you wish to remove Jane Smith?'
   def remove_link(name)
-    remove_links.detect { |link| link['data-confirm'].include?(name) }
+    remove_links.detect { |link| link["data-confirm"].include?(name) }
   end
 
 end

--- a/features/page_objects/postcode_page.rb
+++ b/features/page_objects/postcode_page.rb
@@ -1,11 +1,11 @@
 class PostCodePage < SitePrism::Page
 
-  element(:local_authority_postcode, "input[id='local_authority_postcode_postcode']")
-  element(:ltd_company_postcode, "input[id='limited_company_postcode_postcode']")
-  element(:llp_postcode, "input[id='limited_liability_partnership_postcode_postcode']")
-  element(:individual_postcode, "input[id='individual_postcode_postcode']")
-  element(:other_postcode, "input[id='other_postcode_postcode']")
-  element(:partnership_postcode, "input[id='partnership_postcode_postcode']")
+  element(:local_authority_postcode, "input#local_authority_postcode_postcode")
+  element(:ltd_company_postcode, "input#limited_company_postcode_postcode")
+  element(:llp_postcode, "input#limited_liability_partnership_postcode_postcode")
+  element(:individual_postcode, "input#individual_postcode_postcode")
+  element(:other_postcode, "input#other_postcode_postcode")
+  element(:partnership_postcode, "input#partnership_postcode_postcode")
 
   element(:submit_button, "input[name='commit']")
 

--- a/features/page_objects/registration_number_page.rb
+++ b/features/page_objects/registration_number_page.rb
@@ -1,6 +1,8 @@
 class RegistrationNumberPage < SitePrism::Page
-  element(:ltd_reg_number, "input[id='limited_company_number_registration_number']")
-  element(:llp_reg_number, "input[id='limited_liability_partnership_number_registration_number']")
+
+  element(:ltd_reg_number, "input#limited_company_number_registration_number")
+  element(:llp_reg_number, "input#limited_liability_partnership_number_registration_number")
+
   element(:submit_button, "input[name='commit']")
 
   def submit(args = {})

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -1,12 +1,12 @@
 class SearchPage < SitePrism::Page
 
-  element(:alert_success, "div.alert-success[role='alert']", text: 'successfully signed in')
+  element(:alert_success, "div.alert-success[role='alert']", text: "successfully signed in")
 
-  element(:search_field, 'input#search')
-  element(:search_status_dropdown, 'select#search_status')
+  element(:search_field, "input#search")
+  element(:search_status_dropdown, "select#search_status")
 
   element(:search_button, "input[type='submit'][value='Search']")
 
-  section(:nav_bar, AdminNavBarSection, '.navbar-collapse')
+  section(:nav_bar, AdminNavBarSection, ".navbar-collapse")
 
 end

--- a/features/step_definitions/back_office/admin_login_steps.rb
+++ b/features/step_definitions/back_office/admin_login_steps.rb
@@ -2,8 +2,8 @@ Given(/^I have a valid username and password$/) do
 
   # Back office login page
   @app.login_page.submit(
-    email: 'alan.cruikshanks@environment-agency.gov.uk',
-    password: 'Abcde12345'
+    email: "alan.cruikshanks@environment-agency.gov.uk",
+    password: "Abcde12345"
   )
 
 end
@@ -12,8 +12,8 @@ Given(/^I have an invalid username and password$/) do
 
   # Back office login page
   @app.login_page.submit(
-    email: 'mister.tumble@example.co.uk',
-    password: 'Abcde12345'
+    email: "mister.tumble@example.co.uk",
+    password: "Abcde12345"
   )
 
 end

--- a/features/step_definitions/continuous_integration_steps.rb
+++ b/features/step_definitions/continuous_integration_steps.rb
@@ -1,5 +1,5 @@
 Given(/^a cucumber that is (\d+) cm long$/) do |length|
-  @cucumber = { color: 'green', length: length.to_i }
+  @cucumber = { color: "green", length: length.to_i }
 end
 
 When(/^I (?:cut|chop) (?:it|the cucumber) in (?:halves|half|two)$/) do

--- a/features/step_definitions/front_office/check_your_answers_steps.rb
+++ b/features/step_definitions/front_office/check_your_answers_steps.rb
@@ -1,31 +1,31 @@
 And(/^complete the remaining steps as an individual$/) do
 
   # Organisation name page
-  @app.organisation_name_page.submit(individual_name: 'Napoleon Solo')
+  @app.organisation_name_page.submit(individual_name: "Napoleon Solo")
 
   # Postcode page
-  @app.postcode_page.submit(individual_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(individual_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Napoleon Solo',
-    position: 'Owner'
+    full_name: "Napoleon Solo",
+    position: "Owner"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
@@ -36,30 +36,30 @@ end
 Then(/^I will see all the details I entered as an individual$/) do
 
   # Check your answers page
-  expect(page).to have_content 'Electrical cable service crossing over a main river'
-  expect(page).to have_content 'ST 58132 72695'
-  expect(page).to have_content 'Location of activity'
-  expect(page).to have_content 'Individual'
-  expect(page).to have_content 'Napoleon Solo'
-  expect(page).to have_content 'HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
-  expect(page).to have_content 'Napoleon Solo (Owner)'
-  expect(page).to have_content '01234567899'
-  expect(page).to have_content 'tim.stone.ea@gmail.com'
+  expect(page).to have_content "Electrical cable service crossing over a main river"
+  expect(page).to have_content "ST 58132 72695"
+  expect(page).to have_content "Location of activity"
+  expect(page).to have_content "Individual"
+  expect(page).to have_content "Napoleon Solo"
+  expect(page).to have_content "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  expect(page).to have_content "Napoleon Solo (Owner)"
+  expect(page).to have_content "01234567899"
+  expect(page).to have_content "tim.stone.ea@gmail.com"
 
 end
 
 Then(/^I will see all the details I entered as a partnership$/) do
 
   # Check your answers page
-  expect(page).to have_content 'Electrical cable service crossing over a main river'
-  expect(page).to have_content 'ST 58132 72695'
-  expect(page).to have_content 'Location of activity'
-  expect(page).to have_content 'Partnership'
-  expect(page).to have_content 'Steve Rogers, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
-  expect(page).to have_content 'Bruce Banner, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
-  expect(page).to have_content 'Tony Stark, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
-  expect(page).to have_content 'Nick Fury (Project Manager)'
-  expect(page).to have_content '01234567899'
-  expect(page).to have_content 'tim.stone.ea@gmail.com'
+  expect(page).to have_content "Electrical cable service crossing over a main river"
+  expect(page).to have_content "ST 58132 72695"
+  expect(page).to have_content "Location of activity"
+  expect(page).to have_content "Partnership"
+  expect(page).to have_content "Steve Rogers, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  expect(page).to have_content "Bruce Banner, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  expect(page).to have_content "Tony Stark, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  expect(page).to have_content "Nick Fury (Project Manager)"
+  expect(page).to have_content "01234567899"
+  expect(page).to have_content "tim.stone.ea@gmail.com"
 
 end

--- a/features/step_definitions/front_office/individual_steps.rb
+++ b/features/step_definitions/front_office/individual_steps.rb
@@ -1,39 +1,39 @@
 Given(/^I am an individual$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'individual')
+  @app.user_type_page.submit(org_type: "individual")
 
   # Organisation name page
-  @app.organisation_name_page.submit(individual_name: 'Tina Turner')
+  @app.organisation_name_page.submit(individual_name: "Tina Turner")
 
   # Postcode page
-  @app.postcode_page.submit(individual_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(individual_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/llp_partnership_steps.rb
+++ b/features/step_definitions/front_office/llp_partnership_steps.rb
@@ -1,42 +1,42 @@
 Given(/^I am a limited liability partnership$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'limited_liability_partnership')
+  @app.user_type_page.submit(org_type: "limited_liability_partnership")
 
   # Limited company number page
-  @app.registration_number_page.submit(llp_reg_number: '12345678')
+  @app.registration_number_page.submit(llp_reg_number: "12345678")
 
   # Organisation name page
-  @app.organisation_name_page.submit(llp_name: 'LLP R US')
+  @app.organisation_name_page.submit(llp_name: "LLP R US")
 
   # Postcode page
-  @app.postcode_page.submit(llp_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(llp_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/local_authority_steps.rb
+++ b/features/step_definitions/front_office/local_authority_steps.rb
@@ -1,39 +1,39 @@
 Given(/^I am a local authority$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'local_authority')
+  @app.user_type_page.submit(org_type: "local_authority")
 
   # Organisation name page
-  @app.organisation_name_page.submit(local_authority_name: 'Testminster council')
+  @app.organisation_name_page.submit(local_authority_name: "Testminster council")
 
   # Postcode page
-  @app.postcode_page.submit(local_authority_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(local_authority_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   @app.check_your_answers_page.submit_button.click

--- a/features/step_definitions/front_office/ltd_company_steps.rb
+++ b/features/step_definitions/front_office/ltd_company_steps.rb
@@ -1,42 +1,42 @@
 Given(/^I am a limited company$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'limited_company')
+  @app.user_type_page.submit(org_type: "limited_company")
 
   # Limited company number page
-  @app.registration_number_page.submit(ltd_reg_number: '12345678')
+  @app.registration_number_page.submit(ltd_reg_number: "12345678")
 
   # Organisation name page
-  @app.organisation_name_page.submit(ltd_company_name: 'Too unlimited')
+  @app.organisation_name_page.submit(ltd_company_name: "Too unlimited")
 
   # Postcode page
-  @app.postcode_page.submit(ltd_company_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(ltd_company_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/other_registration_steps.rb
+++ b/features/step_definitions/front_office/other_registration_steps.rb
@@ -1,39 +1,39 @@
 Given(/^I am a charity$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'other')
+  @app.user_type_page.submit(org_type: "other")
 
   # Organisation name page
-  @app.organisation_name_page.submit(other_name: 'Boy scouts')
+  @app.organisation_name_page.submit(other_name: "Boy scouts")
 
   # Postcode page
-  @app.postcode_page.submit(other_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(other_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   # Check your answers page

--- a/features/step_definitions/front_office/partnership_steps.rb
+++ b/features/step_definitions/front_office/partnership_steps.rb
@@ -1,17 +1,17 @@
 # rubocop:disable Metrics/BlockLength
 Given(/^I am a partnership$/) do
   # User type page
-  @app.user_type_page.submit(org_type: 'partnership')
+  @app.user_type_page.submit(org_type: "partnership")
 
   # Organisation name page
-  @app.organisation_name_page.submit(partnership_full_name: 'Mickey Mouse')
+  @app.organisation_name_page.submit(partnership_full_name: "Mickey Mouse")
 
   # Postcode page
-  @app.postcode_page.submit(partnership_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(partnership_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page
@@ -20,7 +20,7 @@ Given(/^I am a partnership$/) do
   @app.partnership_details_page.add_partner_link.click
 
   # Organisation name page
-  @app.organisation_name_page.submit(partnership_full_name: 'Mickey Mouse')
+  @app.organisation_name_page.submit(partnership_full_name: "Mickey Mouse")
 
   # Postcode page
   # We can just click submit because the page pre-populates the postcode lookup
@@ -29,7 +29,7 @@ Given(/^I am a partnership$/) do
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page - again!
@@ -38,25 +38,25 @@ Given(/^I am a partnership$/) do
 
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
-    full_name: 'Joe Bloggs',
-    position: 'Project Manager'
+    full_name: "Joe Bloggs",
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page
   @app.email_someone_else_page.submit(
-    email: 'tim.stone.ea+1@gmail.com',
-    confirm_email: 'tim.stone.ea+1@gmail.com'
+    email: "tim.stone.ea+1@gmail.com",
+    confirm_email: "tim.stone.ea+1@gmail.com"
   )
 
   # Check your answers page
@@ -70,11 +70,11 @@ And(/^add "([^"]*)" as the first partner$/) do |name|
   @app.organisation_name_page.submit(partnership_full_name: name)
 
   # Postcode page
-  @app.postcode_page.submit(partnership_postcode: 'BS1 5AH')
+  @app.postcode_page.submit(partnership_postcode: "BS1 5AH")
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
 end
@@ -94,7 +94,7 @@ And(/^add "([^"]*)" as a partner$/) do |name|
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
 end
@@ -114,7 +114,7 @@ And(/^add "([^"]*)" as the last partner$/) do |name|
 
   # Address page - select address from post code lookup list
   @app.address_page.submit(
-    result: 'ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH'
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
 
   # Partnership details page
@@ -140,7 +140,7 @@ end
 Then(/^I will just see the remaining 2 partners$/) do
 
   expect(@app.partnership_details_page.remove_links.length).to eq(2)
-  expect(page).to have_content('Steve Rogers')
-  expect(page).to have_content('Tony Stark')
+  expect(page).to have_content("Steve Rogers")
+  expect(page).to have_content("Tony Stark")
 
 end

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -27,8 +27,8 @@ Given(/^I register exemption FRA(\d+)$/) do |code|
   @app.check_exemptions_page.submit_button.click
 
   @app.grid_reference_page.submit(
-    grid_reference: 'ST 58132 72695',
-    description: 'Location of activity'
+    grid_reference: "ST 58132 72695",
+    description: "Location of activity"
   )
 
 end
@@ -52,8 +52,8 @@ When(/^I select exemption FRA(\d+) as a "([^"]*)"$/) do |code, org_type|
 
   # Grid reference page
   @app.grid_reference_page.submit(
-    grid_reference: 'ST 58132 72695',
-    description: 'Location of activity'
+    grid_reference: "ST 58132 72695",
+    description: "Location of activity"
   )
 
   # User type page
@@ -99,7 +99,7 @@ Given(/^I then opt to change FRA(\d+)$/) do |code|
 end
 
 Then(/^I will be taken back to the add exemptions page$/) do
-  expect(page).to have_content 'Select the exemption you want to register'
+  expect(page).to have_content "Select the exemption you want to register"
 end
 
 When(/^I confirm my registration$/) do
@@ -107,7 +107,7 @@ When(/^I confirm my registration$/) do
 end
 
 Then(/^I will see confirmation my registration has been submitted$/) do
-  expect(page).to have_content 'Registration submitted '
+  expect(page).to have_content "Registration submitted "
 end
 
 And(/^give "([^"]*)" as the contact$/) do |name|
@@ -115,18 +115,18 @@ And(/^give "([^"]*)" as the contact$/) do |name|
   # Correspondence contact name page
   @app.correspondence_contact_name_page.submit(
     full_name: name,
-    position: 'Project Manager'
+    position: "Project Manager"
   )
 
   # Correspondence contact telephone page
   @app.correspondence_contact_telephone_page.submit(
-    telephone_number: '01234567899'
+    telephone_number: "01234567899"
   )
 
   # Correspondence contact email address page
   @app.correspondence_contact_email_page.submit(
-    email: 'tim.stone.ea@gmail.com',
-    confirm_email: 'tim.stone.ea@gmail.com'
+    email: "tim.stone.ea@gmail.com",
+    confirm_email: "tim.stone.ea@gmail.com"
   )
 
   # Email someone else page


### PR DESCRIPTION
This PR covers some housekeeping on the code base

- Adding a new rule to `.rubocop.yml` which brings the project inline with other **Ruby** based EA projects
- Updating any attribute selectors in the page objects which were just selecting by id to use the standard CSS select by id format (i.e. `element#id`)