### PR TITLE
Override back office url logic with env var value

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Into that file you'll need to add the `app_host:` entry, with the url of the FRA
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**.
 
+### Back office
+
+The project contains logic to automatically determine the URL to the back office, by assuming `app_host:` is the front office URL for one of our standard environments (development, QA, pre-prod or production).
+
+This means you can run all the tests, even though you have only given **Quke** details for the front office.
+
+However if you're not running the project against one of these standard environments (for example you are running against a deployment in [Heroku](https://heroku.com), or something you have running locally) you can override this logic and simply tell **Quke** the back office URL via an environment variable.
+
+```bash
+FRAE_BO_URL="http://localhost:3001" bundle exec quke --tags ~@ci
+```
+
 ## Execution
 
 Simply call

--- a/features/page_objects/back_office_home_page.rb
+++ b/features/page_objects/back_office_home_page.rb
@@ -7,6 +7,10 @@ class BackOfficeHomePage < SitePrism::Page
   # N.B. set as a class method because its intended caller is set_url(), which
   # is also a class method.
   def self.convert_url
+    # Shortcut override - if an env var is set use its value rather than
+    # attempting to convert the url supplied in .config.yml
+    return ENV["FRAE_BO_URL"] if ENV["FRAE_BO_URL"]
+
     host_url = Capybara.app_host
     prefix = "https://admin-"
 


### PR DESCRIPTION
Currently `/features/page_objects/back_office_home_page.rb` features logic to convert the url supplied by the `.config.yml` into its back office variant.

That's great when we are working with the standard environments, but should we wish to go against another (for example Heroku) its url's don't follow this pattern and therefore it breaks.

Therefore this change updates the logic to look for an env var containing the alternative url to use, and which if found will override whatever the url conversion logic would have produced.