### PR TITLE
Add home link to admin nav bar section object

### DIFF
--- a/features/page_objects/admin_nav_bar_section.rb
+++ b/features/page_objects/admin_nav_bar_section.rb
@@ -14,6 +14,12 @@ class AdminNavBarSection < SitePrism::Section
   # confirm/test its working. See
   # https://developers.google.com/web/updates/2015/05/search-dom-tree-by-css-selector
 
+  # Finally the root selector for this section appears to be
+  # ".add-bottom-margin .container". So when adding it to you're pages use
+  # section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
+
+  element(:home_link, "a.navbar-brand")
+
   element(:registrations_menu, ".dropdown:nth-child(1) .dropdown-toggle")
   element(:search_option, ".dropdown-menu li:nth-child(1) a")
   element(:new_option, ".dropdown-menu li:nth-child(2) a")

--- a/features/page_objects/search_page.rb
+++ b/features/page_objects/search_page.rb
@@ -7,6 +7,6 @@ class SearchPage < SitePrism::Page
 
   element(:search_button, "input[type='submit'][value='Search']")
 
-  section(:nav_bar, AdminNavBarSection, ".navbar-collapse")
+  section(:nav_bar, AdminNavBarSection, ".add-bottom-margin .container")
 
 end


### PR DESCRIPTION
Currently the `AdminNavBarSection` does not capture the home link. In other projects this has found to be a useful option to have so this change ensures it's available to access from the admin nav bar section.